### PR TITLE
Altera ordem do bundle-audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_script:
   - gem install bundle-audit
 
 script:
+  - bundle-audit check --update
   - export CODACY_PROJECT_TOKEN
   - export INTEGRATION_KEY
   - export INTEGRATION_URL
   - RAILS_ENV=test bundle exec rake db:test:prepare
   - bundle exec rspec
-  - bundle-audit check --update


### PR DESCRIPTION
Isso permite que falhas sejam identificadas rapidamente durante a execução do CI